### PR TITLE
Update graph edges during orchestration.

### DIFF
--- a/src/main/java/at/uibk/dps/ee/model/graph/AbstractConcurrentGraph.java
+++ b/src/main/java/at/uibk/dps/ee/model/graph/AbstractConcurrentGraph.java
@@ -358,7 +358,7 @@ public class AbstractConcurrentGraph<V extends Node, E extends Edge> extends Gra
 
   @Override
   public Pair<V> getEndpoints(final E edge) {
-    throw new IllegalAccessError(excMessageWrongMethod);
+    return super.getEndpoints(edge);
   }
 
   @Override

--- a/src/main/java/at/uibk/dps/ee/model/graph/MappingsConcurrent.java
+++ b/src/main/java/at/uibk/dps/ee/model/graph/MappingsConcurrent.java
@@ -106,7 +106,7 @@ public class MappingsConcurrent implements Iterable<Mapping<Task, Resource>> {
   public Set<Task> getSources(final Resource resource) {
     if (resourceMappings.containsKey(resource.getId())) {
       return resourceMappings.get(resource.getId()).values().stream()
-          .map(mapping -> mapping.getSource()).collect(Collectors.toSet());
+          .map(Mapping::getSource).collect(Collectors.toSet());
     } else {
       return new HashSet<>();
     }
@@ -122,7 +122,7 @@ public class MappingsConcurrent implements Iterable<Mapping<Task, Resource>> {
    */
   public Set<Resource> getTargets(final Task task) {
     if (taskMappings.containsKey(task.getId())) {
-      return taskMappings.get(task.getId()).values().stream().map(mapping -> mapping.getTarget())
+      return taskMappings.get(task.getId()).values().stream().map(Mapping::getTarget)
           .collect(Collectors.toSet());
     } else {
       return new HashSet<>();


### PR DESCRIPTION
Implements a method in `AbstractConcurrentGraph.java`. This is required for the update of edge in the resource graph during orchestration.